### PR TITLE
upgrade from Style/Blocks to Style/BlockDelimiters

### DIFF
--- a/pusher-rubocop.yml
+++ b/pusher-rubocop.yml
@@ -10,7 +10,7 @@ Lint/Debugger:
     - debug.rb
 
 # We use multi-line {...} for async blocks
-Style/Blocks:
+Style/BlockDelimiters:
   Enabled: false
 
 Style/FileName:


### PR DESCRIPTION
Later versions of rubocop use Style/BlockDelimiters instead of Style/Blocks.

I'm not quite sure when this change happened in rubocop history, and also when the remote file thing became available.
